### PR TITLE
W-9118085 Share Button Available on Review, Funding Request and Requirements Object

### DIFF
--- a/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
@@ -315,7 +315,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>\00h2D000002AEXN</masterLabel>
+        <masterLabel>00h2D000002AEXN</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
@@ -200,11 +200,6 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>FeedItem.TextPost</actionName>
-            <actionType>QuickAction</actionType>
-            <sortOrder>0</sortOrder>
-        </platformActionListItems>
-        <platformActionListItems>
             <actionName>Funding_Request__c.Create_Bulk_Disbursements</actionName>
             <actionType>QuickAction</actionType>
             <sortOrder>1</sortOrder>
@@ -243,6 +238,16 @@
             <actionName>Delete</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>8</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>Share</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>9</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>FeedItem.TextPost</actionName>
+            <actionType>QuickAction</actionType>
+            <sortOrder>0</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <relatedLists>
@@ -310,7 +315,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h2D000002AEXN</masterLabel>
+        <masterLabel>00h2D000001yQY1</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Funding_Request__c-Funding Request Layout.layout-meta.xml
@@ -315,7 +315,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h2D000001yQY1</masterLabel>
+        <masterLabel>\00h2D000002AEXN</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Requirement__c-Requirement Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Requirement__c-Requirement Layout.layout-meta.xml
@@ -139,14 +139,14 @@
             <sortOrder>4</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>FeedItem.TextPost</actionName>
-            <actionType>QuickAction</actionType>
-            <sortOrder>6</sortOrder>
-        </platformActionListItems>
-        <platformActionListItems>
             <actionName>SendEmail</actionName>
             <actionType>QuickAction</actionType>
             <sortOrder>5</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>FeedItem.TextPost</actionName>
+            <actionType>QuickAction</actionType>
+            <sortOrder>6</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>FeedItem.ContentPost</actionName>
@@ -157,6 +157,11 @@
             <actionName>FeedItem.PollPost</actionName>
             <actionType>QuickAction</actionType>
             <sortOrder>8</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>Share</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>9</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <quickActionList>

--- a/force-app/main/default/layouts/Review__c-Review Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Review__c-Review Layout.layout-meta.xml
@@ -2,7 +2,6 @@
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <excludeButtons>ChangeRecordType</excludeButtons>
     <excludeButtons>IsotopeSubscription</excludeButtons>
-    <excludeButtons>Share</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
@@ -112,6 +111,11 @@
             <actionName>PrintableView</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>6</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>Share</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>7</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>Edit</actionName>


### PR DESCRIPTION
Screenshot of how the new Sharing button displays on page layouts:

![Screen Shot 2021-04-26 at 2 43 39 PM](https://user-images.githubusercontent.com/1134606/116150005-0bed2080-a6a0-11eb-8c1c-2fac4c0fc509.png)

# Critical Changes

# Changes

Adds the Sharing button to the Lightning page layouts for the Review, Funding Request, and Requirement objects.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- ~[ ] Any net new LWC work has JEST test coverage 50% or above~
- ~[ ] Default Sa11y tests pass for all LWC components~
- ~[ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- ~[ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [x] **All acceptance criteria have been met**
    - [x] Developer
    - [x] Code Reviewer
- [x] Pull Request contains draft release notes
- ~[ ] Labels, help text, and customer facing messages are reviewed by Docs~
- [ ] QE story level testing completed
