### PR TITLE
W-925119: Update Open Reviews listview to include 'Submitted'

### DIFF
--- a/force-app/main/default/objects/Review__c/listViews/OpenReviews.listView-meta.xml
+++ b/force-app/main/default/objects/Review__c/listViews/OpenReviews.listView-meta.xml
@@ -11,7 +11,7 @@
     <filters>
         <field>Status__c</field>
         <operation>notEqual</operation>
-        <value>Completed</value>
+        <value>Submitted</value>
     </filters>
     <label>Open Reviews</label>
 </ListView>


### PR DESCRIPTION
Modified the 'Open Reviews' Review object list view filter to include Review records whose status are not equal to 'Submitted' (as opposed to 'Completed'). 
![Screenshot of the 'Open Reviews' Review object list view with the highlighted update of the 'Submitted' Status filter ](https://user-images.githubusercontent.com/55713237/117881455-1f7eb680-b25e-11eb-8fb9-d0b1ffb8afe7.png)

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- ~[ ] Any net new LWC work has JEST test coverage 50% or above~
- ~[ ] Default Sa11y tests pass for all LWC components~
- ~[ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- ~[ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
-~ [ ] Make sure that ACs are updated (if any gaps)~
- [x] **All acceptance criteria have been met**
    - [x] Developer
    - [x] Code Reviewer
- [ ] Pull Request contains draft release notes
- ~[ ] Labels, help text, and customer facing messages are reviewed by Docs~
- [ ] QE story level testing completed
