### PR TITLE
W-8129763: Add tabs component to the Requirement record page to fix heading structure

### DIFF
--- a/force-app/main/default/flexipages/Milestone_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Milestone_Record_Page.flexipage-meta.xml
@@ -7,6 +7,14 @@
                     <name>collapsed</name>
                     <value>false</value>
                 </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>enableActionsConfiguration</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>hideChatterActions</name>
+                    <value>false</value>
+                </componentInstanceProperties>
                 <componentName>force:highlightsPanel</componentName>
             </componentInstance>
         </itemInstances>
@@ -17,7 +25,75 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListContainer</componentName>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-d22cf951-79c7-4eb3-8d5a-d6f82a406513</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
                 <componentName>force:detailPanel</componentName>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-aae2d830-b961-42c8-91e1-e837addbafa7</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>active</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-d22cf951-79c7-4eb3-8d5a-d6f82a406513</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Standard.Tab.relatedLists</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-aae2d830-b961-42c8-91e1-e837addbafa7</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Standard.Tab.detail</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-297e8056-4e8c-407e-b41c-3d52de1f6a73</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>tabs</name>
+                    <value>Facet-297e8056-4e8c-407e-b41c-3d52de1f6a73</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tabset</componentName>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -46,6 +122,18 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
                 <componentName>force:relatedListContainer</componentName>
             </componentInstance>
         </itemInstances>


### PR DESCRIPTION
WI: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008fyuBIAQ/view

# Dev Changes

Added tabs component to the Requirement record page, and placed the Detail Panel inside the Detail tab, and the Related Lists component inside the Related tab. This fixes the heading structure issue we had, as now the heading structure is logically nested (H1 > H2 > H3).

# Critical Changes

# Changes

Added the **Tabs** component to the **Requirement** object **record page**, and placed the **Detail Panel** inside the **Detail tab**, and the **Related Lists** component inside the **Related tab**. This will improve the accessibility for this record page.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
~~- [ ] Any net new LWC work has JEST test coverage 50% or above~~
~~- [ ] Default Sa11y tests pass for all LWC components~~
~~- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~~
~~- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [x] Developer
    - [ ] Code Reviewer
    - [x] Pull Request contains draft release notes
    - [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
