### PR TITLE
W-10330211 Remove isotope dependency

### DIFF
--- a/force-app/main/default/layouts/Review__c-Review Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Review__c-Review Layout.layout-meta.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
-    <excludeButtons>ChangeRecordType</excludeButtons>
-    <excludeButtons>IsotopeSubscription</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>


### PR DESCRIPTION
[W-10330211](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000Yih5hYAB/view)

Changes to `Review__c-Review Layout.layout-meta.xml`:
- Removes isotope dependency by not excluding `IsotopeSubscription` button.
- Removes excluding `ChangeRecordType` to be consistent with all other layouts.

# Critical Changes

# Changes
Review Layout no longer excludes IsotopeSubscription and ChangeRecordType buttons.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [x] Any net new LWC work has JEST test coverage 50% or above
- [x] Default Sa11y tests pass for all LWC components
- [x] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [x] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [x] Developer
    - [ ] Code Reviewer
- [x] Pull Request contains draft release notes
- [x] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
