### PR TITLE
W-12674462 - Update cumulusci.yml for static release notes

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,3 +1,4 @@
+minimum_cumulusci_version: 3.74.0
 project:
     name: OutboundFunds
     source_format: sfdx
@@ -78,6 +79,12 @@ tasks:
         options:
             path: robot/OutboundFunds/resources/unpackaged/qa
 
+    github_release:
+            options:
+                release_content: |
+                    Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
+
+
 flows:
     config_dev:
         steps:
@@ -123,6 +130,11 @@ flows:
                 flow: npsp:install_prod
             2:
                 task: bridge:install_managed
+
+    release_production:
+            steps:
+                3:
+                    task: None
 
 orgs:
     scratch:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -80,9 +80,9 @@ tasks:
             path: robot/OutboundFunds/resources/unpackaged/qa
 
     github_release:
-            options:
-                release_content: |
-                    Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
+        options:
+            release_content: |
+                Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
 
 flows:
     config_dev:
@@ -131,9 +131,9 @@ flows:
                 task: bridge:install_managed
 
     release_production:
-            steps:
-                3:
-                    task: None
+        steps:
+            3:
+                task: None
 
 orgs:
     scratch:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -84,7 +84,6 @@ tasks:
                 release_content: |
                     Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
 
-
 flows:
     config_dev:
         steps:


### PR DESCRIPTION
Related WI: [W-12674462](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Mz9NwYAJ/view)
Related TD: [TD-0127818](https://gus.lightning.force.com/lightning/r/a0nEE0000008Y2vYAE/view)

Update cumulusci.yml to use static release notes (instead of dynamic-generated ones) that redirect to the H&T SFDO release notes


# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] Any net new LWC work has JEST test coverage 50% or above
- [ ] Default Sa11y tests pass for all LWC components
- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
