### PR TITLE
Feature/244  scheduled date mismatches with first date while scheduling disbursements

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,3 +1,4 @@
+minimum_cumulusci_version: 3.74.0
 project:
     name: OutboundFunds
     source_format: sfdx
@@ -78,6 +79,11 @@ tasks:
         options:
             path: robot/OutboundFunds/resources/unpackaged/qa
 
+    github_release:
+        options:
+            release_content: |
+                Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
+
 flows:
     config_dev:
         steps:
@@ -123,6 +129,11 @@ flows:
                 flow: npsp:install_prod
             2:
                 task: bridge:install_managed
+
+    release_production:
+        steps:
+            3:
+                task: None
 
 orgs:
     scratch:

--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
@@ -82,7 +82,7 @@
                 if (intervalType == WEEK) {
                     dateObject.setDate(dateObject.getDate() + interval * 7);
                 } else if (intervalType == MONTH) {
-                    dateObject = this.addMonths(dateObject, interval);
+                    dateObject.setMonth(dateObject.getMonth() + interval);
                 } else if (intervalType == YEAR) {
                     dateObject.setFullYear(dateObject.getFullYear() + interval);
                 }

--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
@@ -82,7 +82,7 @@
                 if (intervalType == WEEK) {
                     dateObject.setDate(dateObject.getDate() + interval * 7);
                 } else if (intervalType == MONTH) {
-                    dateObject.setMonth(dateObject.getMonth() + interval);
+                    dateObject = this.addMonths(dateObject, interval);
                 } else if (intervalType == YEAR) {
                     dateObject.setFullYear(dateObject.getFullYear() + interval);
                 }
@@ -181,20 +181,12 @@
 
     addMonths: function (date, count) {
         if (date && count) {
-            console.log("184 date ", date);
             var m,
                 d = (date = new Date(+date)).getUTCDate();
-            console.log("getUTCMonth ", date.getUTCMonth());
-            console.log("count ", count);
-            console.log("d ", d);
+
             date.setUTCMonth(date.getUTCMonth() + count, 1);
-            console.log("188 date ", date);
             m = date.getUTCMonth();
             date.setUTCDate(d);
-            console.log("190 date ", date);
-            console.log("191 m ", m);
-            console.log("utc m ", date.getUTCMonth());
-
             if (date.getUTCMonth() !== m) date.setUTCDate(0);
         }
         return date;

--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
@@ -104,7 +104,7 @@
                 // Calculated Properties
                 id: "" + i, // A workaround to force the datatable to see this id as a string
                 amount: thisPayment,
-                scheduleDate: dateObject.toISOString().split("T")[0],
+                scheduleDate: $A.localizationService.formatDate(dateObject.toISOString(), 'YYYY-MM-DD'),
                 requestId: m.request.recordId
             });
         }

--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
@@ -82,7 +82,7 @@
                 if (intervalType == WEEK) {
                     dateObject.setDate(dateObject.getDate() + interval * 7);
                 } else if (intervalType == MONTH) {
-                    dateObject = this.addMonths(dateObject, interval);
+                    dateObject.setMonth(dateObject.getMonth() + interval);
                 } else if (intervalType == YEAR) {
                     dateObject.setFullYear(dateObject.getFullYear() + interval);
                 }
@@ -181,12 +181,20 @@
 
     addMonths: function (date, count) {
         if (date && count) {
+            console.log("184 date ", date);
             var m,
                 d = (date = new Date(+date)).getUTCDate();
-
+            console.log("getUTCMonth ", date.getUTCMonth());
+            console.log("count ", count);
+            console.log("d ", d);
             date.setUTCMonth(date.getUTCMonth() + count, 1);
+            console.log("188 date ", date);
             m = date.getUTCMonth();
             date.setUTCDate(d);
+            console.log("190 date ", date);
+            console.log("191 m ", m);
+            console.log("utc m ", date.getUTCMonth());
+
             if (date.getUTCMonth() !== m) date.setUTCDate(0);
         }
         return date;

--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreateHelper.js
@@ -104,7 +104,10 @@
                 // Calculated Properties
                 id: "" + i, // A workaround to force the datatable to see this id as a string
                 amount: thisPayment,
-                scheduleDate: $A.localizationService.formatDate(dateObject.toISOString(), 'YYYY-MM-DD'),
+                scheduleDate: $A.localizationService.formatDate(
+                    dateObject.toISOString(),
+                    "YYYY-MM-DD"
+                ),
                 requestId: m.request.recordId
             });
         }


### PR DESCRIPTION
# Critical Changes
GUS [W-12591694](https://gus.lightning.force.com/a07EE00001LmAr3YAF)
Updated AuraComponent disbursementsCreate's disbursementsCreateHelper
calcDisp of disbursementsCreateHelper.js is used to calculate the disbursement scheduled date. Previously toISOString is used to get the schedule date and it was returning one day before the first date. We have now used toISOString with formatDate to get the correct schedule date.
In disbursementsCreateHelper.js, we have also used the setMonth() method of the Standard Date class and pass the date (i.e dateObject with the passed interval added with it ).
# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] Any net new LWC work has JEST test coverage 50% or above
- [ ] Default Sa11y tests pass for all LWC components
- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
