### PR TITLE
W-13205093 - WCAG-2.1-Color-Contrast-Changes

### DIFF
--- a/force-app/main/default/aura/disbursementsCreate/disbursementsCreate.cmp
+++ b/force-app/main/default/aura/disbursementsCreate/disbursementsCreate.cmp
@@ -18,7 +18,7 @@
 
         <div class="slds-section slds-is-open">
             <!-- Funding Request Data -->
-            <h3 class="slds-section__title slds-theme_shade">
+            <h3 class="slds-section__title">
                 <span
                     class="slds-truncate slds-p-horizontal_small"
                     title="{!$Label.c.disbursementsCreate_FundingRequestInformation}"
@@ -28,19 +28,11 @@
             <div class="slds-section__content">
                 <div class="slds-grid slds-grid_pull-padded-medium slds-m-bottom_large">
                     <div
-                        class="
-                            slds-p-horizontal_medium
-                            slds-size_1-of-2
-                            slds-region_narrow
-                        "
+                        class="slds-p-horizontal_medium slds-size_1-of-2 slds-region_narrow"
                     >
                         <dl class="slds-dl_inline slds-wrap">
                             <dt
-                                class="
-                                    slds-dl_inline__label
-                                    slds-text-color_weak
-                                    slds-truncate
-                                "
+                                class="slds-dl_inline__label slds-text-color_weak slds-truncate"
                             >
                                 {!v.model.request.fundingRequestLabels.Applying_Contact__c}:
                             </dt>
@@ -48,11 +40,7 @@
                                 {!v.model.request.contactName}
                             </dd>
                             <dt
-                                class="
-                                    slds-dl_inline__label
-                                    slds-text-color_weak
-                                    slds-truncate
-                                "
+                                class="slds-dl_inline__label slds-text-color_weak slds-truncate"
                             >
                                 {!v.model.request.fundingRequestLabels.Awarded_Amount__c}:
                             </dt>
@@ -66,19 +54,11 @@
                     </div>
 
                     <div
-                        class="
-                            slds-p-horizontal_medium
-                            slds-size_1-of-2
-                            slds-region_narrow
-                        "
+                        class="slds-p-horizontal_medium slds-size_1-of-2 slds-region_narrow"
                     >
                         <dl class="slds-dl_inline slds-wrap">
                             <dt
-                                class="
-                                    slds-dl_inline__label
-                                    slds-text-color_weak
-                                    slds-truncate
-                                "
+                                class="slds-dl_inline__label slds-text-color_weak slds-truncate"
                             >
                                 {!v.model.request.fundingRequestLabels.Total_Disbursed__c}:
                             </dt>
@@ -89,11 +69,7 @@
                                 />
                             </dd>
                             <dt
-                                class="
-                                    slds-dl_inline__label
-                                    slds-text-color_weak
-                                    slds-truncate
-                                "
+                                class="slds-dl_inline__label slds-text-color_weak slds-truncate"
                             >
                                 {!v.model.request.fundingRequestLabels.Total_Remaining__c}:
                             </dt>
@@ -107,11 +83,7 @@
                     </div>
                 </div>
                 <div
-                    class="
-                        slds-grid slds-grid_pull-padded-medium
-                        slds-p-left_large
-                        slds-p-right_large
-                    "
+                    class="slds-grid slds-grid_pull-padded-medium slds-p-left_large slds-p-right_large"
                 ></div>
             </div>
 
@@ -120,7 +92,7 @@
                 <aura:iteration items="{!v.model.uiMessages}" var="m">
                     <ui:message
                         title="{!m.title}"
-                        severity="{!m.severity}"
+                        class="slds-theme_error"
                         closable="{!m.closeable}"
                     >
                         {!m.message}
@@ -130,7 +102,7 @@
         </div>
 
         <div class="slds-section slds-is-open">
-            <h3 class="slds-section__title slds-theme_shade">
+            <h3 class="slds-section__title">
                 <span
                     class="slds-truncate slds-p-horizontal_small"
                     title="{!$Label.c.disbursementsCreate_CalculateDisbursements}"
@@ -231,11 +203,7 @@
 
             <!-- Footer -->
             <div
-                class="
-                    slds-section slds-is-open
-                    slds-text-align--center
-                    slds-m-top--medium
-                "
+                class="slds-section slds-is-open slds-text-align--center slds-m-top--medium"
             >
                 <lightning:button
                     label="{!$Label.c.Cancel}"


### PR DESCRIPTION
# Critical Changes
GUS [W-13205093](https://gus.lightning.force.com/a07EE00001RRjuEYAT)
Update Aura Component disbursementsCreate
. Updated disbursementsCreate.cmp - Removed the severity from ui:message tag as it does not meet the WCAG 2.1 color contrast ratio and used slds class slds-theme_error to meet the requirement.
# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] Any net new LWC work has JEST test coverage 50% or above
- [ ] Default Sa11y tests pass for all LWC components
- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
